### PR TITLE
Fix bug in S3 error handler

### DIFF
--- a/src/components/vue-dropzone.vue
+++ b/src/components/vue-dropzone.vue
@@ -159,7 +159,7 @@ export default {
 
     this.dropzone.on("error", function(file, message, xhr) {
       vm.$emit("vdropzone-error", file, message, xhr);
-      if (this.isS3) vm.$emit("vdropzone-s3-upload-error");
+      if (vm.isS3) vm.$emit("vdropzone-s3-upload-error");
     });
 
     this.dropzone.on("errormultiple", function(files, message, xhr) {


### PR DESCRIPTION
## Summary
- fix error event to use `vm.isS3` rather than `this.isS3`

## Testing
- `npm run build` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e26cdb9c832c8da0b48ffd6234be